### PR TITLE
Configurable CRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ your publisher node (camera driver), you can give it a parameter list on the way
         parameters=[{'ffmpeg_image_transport.encoding': 'hevc_nvenc',
                      'ffmpeg_image_transport.profile': 'main',
                      'ffmpeg_image_transport.preset': 'll',
-                     'ffmpeg_image_transport.gop': 15}]
+                     'ffmpeg_image_transport.gop_size': 15}]
 ```
 
 ### Subscriber (viewer)
@@ -189,7 +189,7 @@ nvmpi like so:
         parameters=[{'ffmpeg_image_transport.encoding': 'h264_nvmpi',
                      'ffmpeg_image_transport.profile': 'main',
                      'ffmpeg_image_transport.preset': 'll',
-                     'ffmpeg_image_transport.gop': 15}]
+                     'ffmpeg_image_transport.gop_size': 15}]
 ```
 
 

--- a/include/ffmpeg_image_transport/ffmpeg_encoder.hpp
+++ b/include/ffmpeg_image_transport/ffmpeg_encoder.hpp
@@ -138,6 +138,7 @@ private:
   std::string preset_;     // e.g. "slow", "medium", "lossless"
   std::string profile_;    // e.g. "main", "high", "rext"
   std::string tune_;       // e.g. "tune"
+  std::string crf_;        // The range is [0, 51]; where 0 is lossless, 23 is default and 51 is the worst.
   std::string delay_;      // default is 4 frames for parallel processing. 0 is lowest latency
   int qmax_{0};            // max allowed quantization. The lower the better quality
   int GOPSize_{15};        // distance between two keyframes

--- a/src/ffmpeg_encoder.cpp
+++ b/src/ffmpeg_encoder.cpp
@@ -96,6 +96,7 @@ void FFMPEGEncoder::setParameters(rclcpp::Node * node)
   preset_ = get_safe_param<std::string>(node, ns + "preset", "");
   tune_ = get_safe_param<std::string>(node, ns + "tune", "");
   delay_ = get_safe_param<std::string>(node, ns + "delay", "");
+  crf_ = get_safe_param<std::string>(node, ns + "crf", "");
   qmax_ = get_safe_param<int>(node, ns + "qmax", 10);
   bitRate_ = get_safe_param<int64_t>(node, ns + "bit_rate", 8242880);
   GOPSize_ = get_safe_param<int64_t>(node, ns + "gop_size", 15);
@@ -227,6 +228,7 @@ void FFMPEGEncoder::doOpenCodec(int width, int height)
   setAVOption("preset", preset_);
   setAVOption("tune", tune_);
   setAVOption("delay", delay_);
+  setAVOption("crf", crf_);
   RCLCPP_DEBUG(
     logger_,
     "codec: %10s, profile: %10s, preset: %10s,"


### PR DESCRIPTION
As mentioned in #30 CRF is a parameter that can controll the quality of the compression and can be very significant for low bandwith video streaming. <br>
Also I've noticed that the README.md has the gop parameter named wrong, it should be gop_size.