### PR TITLE
bug: not allowed to cache function pointer, fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Here is a list of the available encoding parameters:
   You can list all available encoders with ``ffmpeg --codecs``. In the h264 row, look for ``(encoders)``.
 - ``preset``: default is empty (""). Valid values can be for instance ``slow``, ``ll`` (low latency) etc.
    To find out what presets are available, run e.g.
-   ``fmpeg -hide_banner -f lavfi -i nullsrc -c:v libx264 -preset help -f mp4 - 2>&1``
+   ``ffmpeg -hide_banner -f lavfi -i nullsrc -c:v libx264 -preset help -f mp4 - 2>&1``
 - ``profile``: For instance ``baseline``, ``main``. See [the ffmpeg website](https://trac.ffmpeg.org/wiki/Encode/H.264).
 - ``tune``: See [the ffmpeg website](https://trac.ffmpeg.org/wiki/Encode/H.264). The default is empty("").
 - ``gop_size``: The number of frames between keyframes. Default: 10.

--- a/src/ffmpeg_publisher.cpp
+++ b/src/ffmpeg_publisher.cpp
@@ -204,8 +204,8 @@ rmw_qos_profile_t FFMPEGPublisher::initialize(
 void FFMPEGPublisher::publish(const Image & msg, const PublishFn & publish_fn) const
 {
   FFMPEGPublisher * me = const_cast<FFMPEGPublisher *>(this);
+  me->publishFunction_ = &publish_fn;
   if (!me->encoder_.isInitialized()) {
-    me->publishFunction_ = &publish_fn;
     if (!me->encoder_.initialize(
           msg.width, msg.height,
           std::bind(&FFMPEGPublisher::packetReady, me, _1, _2, _3, _4, _5, _6, _7, _8, _9))) {


### PR DESCRIPTION
This PR fixes a typo in the README and a bug: the publish function pointer can change on every invocation, see the corresponding PR in [the foxglove compressed video transport](https://github.com/ros-misc-utilities/foxglove_compressed_video_transport/pull/4)
